### PR TITLE
Migrated to KF6/Qt5

### DIFF
--- a/install_kateplugin.sh
+++ b/install_kateplugin.sh
@@ -4,7 +4,7 @@
 search_paths=("/usr/lib64" "/usr/lib")
 
 # Destination path suffix
-path_suffix="qt5/plugins/ktexteditor"
+path_suffix="qt6/plugins/ktexteditor"
 
 # Compiled plugin to copy
 compiled_plugin="build/clang-release/bin/ktexteditor/kate_with_ai.so"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-find_package(ECM "5.68.0" CONFIG REQUIRED)
+find_package(ECM "6.6.0" CONFIG REQUIRED)
 
 list(APPEND CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
 
@@ -10,8 +10,8 @@ include(KDECompilerSettings NO_POLICY_SCOPE)
 include(ECMQtDeclareLoggingCategory)
 
 
-find_package(Qt5 COMPONENTS Widgets WebEngineWidgets REQUIRED)
-find_package(KF5
+find_package(Qt6 COMPONENTS Widgets WebEngineWidgets REQUIRED)
+find_package(KF6
     REQUIRED COMPONENTS
         CoreAddons # Core addons on top of QtCore
         I18n # For localization
@@ -26,7 +26,7 @@ set(CMAKE_AUTORCC ON)
 add_subdirectory(plugin_common)
 add_subdirectory(kate_with_ai)
 
-find_package(KDevPlatform 5.2.40)
+find_package(KDevPlatform 6.0.0)
 if(KDevPlatform_FOUND)
   add_subdirectory(kdevcxx_with_ai)
 endif()

--- a/src/kate_with_ai/CMakeLists.txt
+++ b/src/kate_with_ai/CMakeLists.txt
@@ -15,11 +15,11 @@ target_compile_definitions(kate_with_ai PRIVATE TRANSLATION_DOMAIN="kate_with_ai
 target_link_libraries(kate_with_ai
   kdevcxx_with_ai::plugin_commn
   ${BASIC_LINK_FLAGS}
-  KF5::CoreAddons
-  KF5::I18n
-  KF5::TextEditor
+  KF6::CoreAddons
+  KF6::I18n
+  KF6::TextEditor
   )
 
 install(TARGETS kate_with_ai
-    LIBRARY DESTINATION lib64/qt5/plugins/ktexteditor
+    LIBRARY DESTINATION lib64/qt6/plugins/ktexteditor
 )

--- a/src/kate_with_ai/kate_with_ai.h
+++ b/src/kate_with_ai/kate_with_ai.h
@@ -9,7 +9,7 @@
 #include <ktexteditor/mainwindow.h>
 #include <ktexteditor/view.h>
 #include <kpluginfactory.h>
-#include <kpluginloader.h>
+#include <qpluginloader.h>
 
 #ifndef Q_MOC_RUN
 #include <aiprocess/app_settings.h>
@@ -40,7 +40,7 @@ class kate_with_ai_view : public QWidget
 public:
   explicit kate_with_ai_view(kate_with_ai * plugin, KTextEditor::MainWindow * main_window);
 
-private slots:
+private Q_SLOTS:
   void on_view_changed(KTextEditor::View * view);
   void on_context_menu_about_to_show(KTextEditor::View * view, QMenu * menu);
 

--- a/src/kate_with_ai/kate_with_ai_config_page.cc
+++ b/src/kate_with_ai/kate_with_ai_config_page.cc
@@ -19,13 +19,13 @@ kate_with_ai_config_page::kate_with_ai_config_page(QWidget * parent) : KTextEdit
   );
   }
 
-void kate_with_ai_config_page::emit_changed() { emit changed(); }
+void kate_with_ai_config_page::emit_changed() { Q_EMIT changed(); }
 
 QString kate_with_ai_config_page::name() const { return i18n("OpenAI Configuration"); }
 
 QString kate_with_ai_config_page::fullName() const { return i18n("Configure Open AI Settings"); }
 
-QIcon kate_with_ai_config_page::icon() const { return QIcon::fromTheme("preferences-other"); }
+QIcon kate_with_ai_config_page::icon() const { return QIcon::fromTheme(QLatin1String("preferences-other")); }
 
 void kate_with_ai_config_page::apply() { kdevcxxai::config_page::apply<aiprocess::backend_type_e::kate>(ui); }
 

--- a/src/kdevcxx_with_ai/CMakeLists.txt
+++ b/src/kdevcxx_with_ai/CMakeLists.txt
@@ -11,9 +11,9 @@ kdevplatform_add_plugin(kdevcxx_with_ai
 
 target_link_libraries(kdevcxx_with_ai
     kdevcxx_with_ai::plugin_commn
-    KF5::CoreAddons
-    KF5::I18n
-    KF5::TextEditor
+    KF6::CoreAddons
+    KF6::I18n
+    KF6::TextEditor
     KDev::Interfaces
     ${BASIC_LINK_FLAGS}
 )
@@ -22,11 +22,11 @@ set_target_properties(kdevcxx_with_ai PROPERTIES OUTPUT_NAME "kdevcxx_with_ai")
 
 target_compile_definitions(kdevcxx_with_ai PRIVATE TRANSLATION_DOMAIN="kdevcxx_with_ai")
 
-install(TARGETS kdevcxx_with_ai DESTINATION ${PLUGIN_INSTALL_DIR})
-install(FILES kdevcxx_with_ai.json DESTINATION ${KDE_INSTALL_KSERVICES5DIR})
+# install(TARGETS kdevcxx_with_ai DESTINATION ${PLUGIN_INSTALL_DIR})
+# install(FILES kdevcxx_with_ai.json DESTINATION ${KDE_INSTALL_KSERVICESDIR})
 message(STATUS "PLUGIN_INSTALL_DIR ${PLUGIN_INSTALL_DIR}")
-message(STATUS "KDE_INSTALL_KSERVICES5DIR ${KDE_INSTALL_KSERVICES5DIR}")
+message(STATUS "KDE_INSTALL_KSERVICESDIR ${KDE_INSTALL_KSERVICESDIR}")
 
 install(TARGETS kdevcxx_with_ai
-    LIBRARY DESTINATION lib64/qt5/plugins/kdevplatform/513
+    LIBRARY DESTINATION lib64/qt6/plugins/kdevplatform/60
 )

--- a/src/kdevcxx_with_ai/kdevcxx_with_ai.cc
+++ b/src/kdevcxx_with_ai/kdevcxx_with_ai.cc
@@ -5,7 +5,7 @@
 #include "kdevcxx_with_ai_config_page.h"
 
 #include <kpluginfactory.h>
-#include <kpluginloader.h>
+#include <qpluginloader.h>
 #include <info_dialog.h>
 #include <ktexteditor/application.h>
 #include <ktexteditor/mainwindow.h>
@@ -33,7 +33,8 @@ using aiprocess::warn;
 
 K_PLUGIN_FACTORY_WITH_JSON(cxx_with_gptFactory, "kdevcxx_with_ai.json", registerPlugin<kdevcxx_with_ai>();)
 
-kdevcxx_with_ai::kdevcxx_with_ai(QObject * parent, QVariantList const &) : KDevelop::IPlugin("kdevcxx_with_ai", parent)
+kdevcxx_with_ai::kdevcxx_with_ai(QObject * parent, QVariantList const &) :
+  KDevelop::IPlugin(QStringLiteral("kdevcxx_with_ai"), parent, KPluginMetaData())
   {
   log(aiprocess::level::info, "Starting plugin KDevCxx_With_Ai");
   settings = aiprocess::load_app_settings<aiprocess::backend_type_e::kdevelop>();
@@ -57,7 +58,7 @@ void kdevcxx_with_ai::on_first_time()
   aiprocess::warn("cxx_rules {}", aisettings.cxx_rules);
   if(aisettings.api_key.empty())
     {
-    info_dialog dialog("KDevCxx_With_Ai Initialization", kdevcxxai::fist_time_message);
+    info_dialog dialog(QStringLiteral("KDevCxx_With_Ai Initialization"), kdevcxxai::fist_time_message);
     dialog.exec();
     }
   }
@@ -75,13 +76,13 @@ void kdevcxx_with_ai::on_process_with_ai()
 
 void kdevcxx_with_ai::createActionsForMainWindow(Sublime::MainWindow *, QString &, KActionCollection & actions)
   {
-  QAction * process_with_ai_action = new QAction(QIcon(":/icons/my_icon.png"), tr("Process with OpenAI"), this);
+  QAction * process_with_ai_action = new QAction(QIcon(QStringLiteral(":/icons/my_icon.png")), tr("Process with OpenAI"), this);
   process_with_ai_action->setToolTip(tr("Do something interesting with AI"));
 
   process_with_ai_action->setShortcut(settings.activation_keys);
   info("Key for AI binded to {}", settings.activation_keys);
 
-  actions.addAction("process_with_ai", process_with_ai_action);
+  actions.addAction(QStringLiteral("process_with_ai"), process_with_ai_action);
   connect(process_with_ai_action, &QAction::triggered, this, &kdevcxx_with_ai::on_process_with_ai);
   }
 
@@ -94,7 +95,7 @@ auto kdevcxx_with_ai::contextMenuExtension(KDevelop::Context * context, QWidget 
     {
     info("Context menu registered for AI");
     // This is just an example; customize it based on your plugin's functionality
-    QAction * process_with_ai_action = new QAction(QIcon::fromTheme("system-run"), tr("Process with OpenAI"), parent);
+    QAction * process_with_ai_action = new QAction(QIcon::fromTheme(QStringLiteral("system-run")), tr("Process with OpenAI"), parent);
     connect(process_with_ai_action, &QAction::triggered, this, &kdevcxx_with_ai::on_process_with_ai);
 
     // Add your action to the extension

--- a/src/kdevcxx_with_ai/kdevcxx_with_ai.h
+++ b/src/kdevcxx_with_ai/kdevcxx_with_ai.h
@@ -31,10 +31,9 @@ public:
   KDevelop::ConfigPage * configPage(int number, QWidget * parent) override;
   int configPages() const override;
 
-private slots:
+private Q_SLOTS:
 
   void on_process_with_ai();
   void on_first_time();
 
-private:
   };

--- a/src/kdevcxx_with_ai/kdevcxx_with_ai_config_page.cc
+++ b/src/kdevcxx_with_ai/kdevcxx_with_ai_config_page.cc
@@ -19,13 +19,13 @@ kdevcxx_with_ai_config_page::kdevcxx_with_ai_config_page(KDevelop::IPlugin * plu
   );
   }
 
-void kdevcxx_with_ai_config_page::emit_changed() { emit changed(); }
+void kdevcxx_with_ai_config_page::emit_changed() { Q_EMIT changed(); }
 
 QString kdevcxx_with_ai_config_page::name() const { return i18n("OpenAI Configuration"); }
 
 QString kdevcxx_with_ai_config_page::fullName() const { return i18n("Configure Open AI Settings"); }
 
-QIcon kdevcxx_with_ai_config_page::icon() const { return QIcon::fromTheme("preferences-other"); }
+QIcon kdevcxx_with_ai_config_page::icon() const { return QIcon::fromTheme(QLatin1String("preferences-other")); }
 
 void kdevcxx_with_ai_config_page::apply() { kdevcxxai::config_page::apply<aiprocess::backend_type_e::kdevelop>(ui); }
 

--- a/src/plugin_common/CMakeLists.txt
+++ b/src/plugin_common/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(CMAKE_AUTOMOC ON)
 
-find_package(KF5TextEditor REQUIRED)
+find_package(KF6TextEditor REQUIRED)
 
 add_library( plugin_commn STATIC )
 
@@ -14,9 +14,10 @@ target_sources(plugin_commn PRIVATE
 
 target_link_libraries(plugin_commn PUBLIC
     ai_processing::core
-    Qt5::Widgets
-    Qt5::WebEngineWidgets
-    KF5::TextEditor
+    Qt6::Widgets
+    Qt6::WebEngineWidgets
+    KF6::TextEditor
+    KF6::I18n
     ${BASIC_LINK_FLAGS}
 )
 target_compile_options( plugin_commn PUBLIC "-fexceptions")
@@ -25,9 +26,9 @@ target_include_directories( plugin_commn PUBLIC include ${CMAKE_CURRENT_SOURCE_D
 
 
 # add_executable( markdown_view EXCLUDE_FROM_ALL)
-# target_sources(markdown_view PRIVATE 
+# target_sources(markdown_view PRIVATE
 #   markdown_view.cc
 #   markdown_view_test.cc
 # )
-# target_link_libraries(markdown_view Qt5::Widgets Qt5::WebEngineWidgets)
+# target_link_libraries(markdown_view Qt6::Widgets Qt6::WebEngineWidgets)
 # 

--- a/src/plugin_common/include/plugin_common.h
+++ b/src/plugin_common/include/plugin_common.h
@@ -26,11 +26,11 @@ struct app_settings_t;
 namespace kdevcxxai
   {
 inline constexpr auto fist_time_message
-  = "Kindly navigate to the KDevelop settings to provide your API key for activation.\n"
+  = QLatin1String("Kindly navigate to the KDevelop settings to provide your API key for activation.\n"
     " Additionally, fine-tune the AI behavior by adjusting the rule set to your preference.\n"
     "Modifications to the API key or rules can be made at any moment and will be applied immediately,\n"
     "negating the necessity for a KDevelop restart.\n"
-    "Alterations to AI settings will be effective upon the next invocation.";
+    "Alterations to AI settings will be effective upon the next invocation.");
 
 enum class get_view_file_path_error
   {

--- a/src/plugin_common/info_dialog.cc
+++ b/src/plugin_common/info_dialog.cc
@@ -15,7 +15,7 @@ info_dialog::info_dialog(QString const & title, QString const & text, QWidget * 
   layout->addWidget(label);
 
   // Optional: Add a button to close the dialog
-  QPushButton * close_button = new QPushButton("Close", this);
+  QPushButton * close_button = new QPushButton(QLatin1String("Close"), this);
   connect(close_button, &QPushButton::clicked, this, &info_dialog::accept);
   layout->addWidget(close_button);
 

--- a/src/plugin_common/plugin_common.cc
+++ b/src/plugin_common/plugin_common.cc
@@ -57,7 +57,7 @@ auto process_with_ai(KTextEditor::View & view, aiprocess::app_settings_t const &
     auto aisettings{aiprocess::load_ai_settings()};
     if(aisettings.api_key.empty())
       {
-      info_dialog dialog{"KDevCxx_With_Ai key setup", fist_time_message};
+      info_dialog dialog{QStringLiteral("KDevCxx_With_Ai key setup"), fist_time_message};
       dialog.exec();
       return;
       }
@@ -73,7 +73,7 @@ auto process_with_ai(KTextEditor::View & view, aiprocess::app_settings_t const &
     }
 
   info("Processing OpenAI request ...");
-  QProgressDialog progressDialog{"Processing OpenAI Request...", "Cancel", 0, 100};
+  QProgressDialog progressDialog{QStringLiteral("Processing OpenAI Request..."), QStringLiteral("Cancel"), 0, 100};
   progressDialog.setWindowModality(Qt::WindowModal);
   progressDialog.show();
 
@@ -106,7 +106,7 @@ auto process_with_ai(KTextEditor::View & view, aiprocess::app_settings_t const &
         "\ncheck detailed log at ~/.config/kdevcxx_with_ai/"sv,
         settings.log_path
       )),
-      "Error during processing AI request"
+      QStringLiteral("Error during processing AI request")
     );
     return;
     }
@@ -176,11 +176,11 @@ namespace config_page
     QWidget * ai_form_widget = new QWidget();
     QFormLayout * ai_form_layout = new QFormLayout(ai_form_widget);
 
-    ui.openai_key = config_widget_creator_t<QLineEdit>{ai_form_widget, ai_form_layout}("OpenAI Key:", emit_changed);
+    ui.openai_key = config_widget_creator_t<QLineEdit>{ai_form_widget, ai_form_layout}(QStringLiteral("OpenAI Key:"), emit_changed);
     ui.open_ai_model
-      = config_widget_creator_t<QLineEdit>{ai_form_widget, ai_form_layout}("OpenAI Model:", emit_changed);
+      = config_widget_creator_t<QLineEdit>{ai_form_widget, ai_form_layout}(QStringLiteral("OpenAI Model:"), emit_changed);
     ui.language_rules
-      = config_widget_creator_t<QPlainTextEdit>{ai_form_widget, ai_form_layout}("Language Rules:", emit_changed);
+      = config_widget_creator_t<QPlainTextEdit>{ai_form_widget, ai_form_layout}(QStringLiteral("Language Rules:"), emit_changed);
 
     ai_tab_widget->addTab(ai_form_widget, i18n("AI Configuration"));
 
@@ -191,20 +191,21 @@ namespace config_page
 
       {
       config_widget_creator_t<QLineEdit> creator{log_form_widget, log_form_layout};
-      ui.log_path_edit = creator("Log Path:", emit_changed);
-      ui.console_log_pattern_edit = creator("Console Log Pattern:", emit_changed);
-      ui.general_log_pattern_edit = creator("General Log Pattern:", emit_changed);
-      ui.snippet_log_pattern_edit = creator("Snippet Log Pattern:", emit_changed);
-      ui.important_log_pattern_edit = creator("Important Log Pattern:", emit_changed);
+      ui.log_path_edit = creator(QStringLiteral("Log Path:"), emit_changed);
+      ui.console_log_pattern_edit = creator(QLatin1String("Console Log Pattern:"), emit_changed);
+      ui.general_log_pattern_edit = creator(QLatin1String("General Log Pattern:"), emit_changed);
+      ui.snippet_log_pattern_edit = creator(QLatin1String("Snippet Log Pattern:"), emit_changed);
+      ui.important_log_pattern_edit = creator(QLatin1String("Important Log Pattern:"), emit_changed);
       }
 
       {
-      QStringList logLevels = {"trace", "debug", "info", "warn", "error", "critical"};
+      QStringList logLevels = {QLatin1String("trace"), QLatin1String("debug"), QLatin1String("info"),
+                               QLatin1String("warn"), QLatin1String("error"), QLatin1String("critical")};
       config_widget_creator_t<QComboBox> creator{log_form_widget, log_form_layout};
-      ui.console_log_level_combo = creator("Console Log Pattern:", logLevels, emit_changed);
-      ui.general_log_level_combo = creator("General Log Level:", logLevels, emit_changed);
-      ui.snippet_log_level_combo = creator("Snippet Log Pattern:", logLevels, emit_changed);
-      ui.important_log_level_combo = creator("Important Log Pattern:", logLevels, emit_changed);
+      ui.console_log_level_combo = creator(QLatin1String("Console Log Pattern:"), logLevels, emit_changed);
+      ui.general_log_level_combo = creator(QLatin1String("General Log Level:"), logLevels, emit_changed);
+      ui.snippet_log_level_combo = creator(QLatin1String("Snippet Log Pattern:"), logLevels, emit_changed);
+      ui.important_log_level_combo = creator(QLatin1String("Important Log Pattern:"), logLevels, emit_changed);
       }
 
     ui.flush_every_spin = new QSpinBox(log_form_widget);


### PR DESCRIPTION
- use `Qt6` and `KF6` in CMakeLists files
- wrap bare strings with `QLatin1String` or `QStringLiteral` (Qt6 QString(const char*) constructor became private
- use `Q_SLOTS` and `Q_EMIT` apparently (just slots and emit fails to compile)
- use `qpluginloader.h` instead of obsolete `kpluginloader.h`