### PR TITLE
Modernize the codebase

### DIFF
--- a/ai_processing/include/ai_processing.h
+++ b/ai_processing/include/ai_processing.h
@@ -48,7 +48,7 @@ enum struct process_with_ai_error
 consteval auto adl_enum_bounds(process_with_ai_error)
   {
   using enum process_with_ai_error;
-  return simple_enum::adl_info{other_error, no_valid_command};
+  return simple_enum::adl_info{.first = other_error, .last = no_valid_command};
   }
 
 struct model_response_text_t

--- a/ai_processing/include/aiprocess/app_settings.h
+++ b/ai_processing/include/aiprocess/app_settings.h
@@ -22,7 +22,7 @@ enum struct backend_type_e
 consteval auto adl_enum_bounds(backend_type_e)
   {
   using enum backend_type_e;
-  return simple_enum::adl_info{kate, kdevelop};
+  return simple_enum::adl_info{.first = kate, .last = kdevelop};
   }
 
 inline constexpr string_view kdevcxx_with_ai_app_settings_file_name{"kdevcxx_with_ai_app_settings.json"};
@@ -40,7 +40,7 @@ enum struct app_settings_version_e
 consteval auto adl_enum_bounds(app_settings_version_e)
   {
   using enum app_settings_version_e;
-  return simple_enum::adl_info{v1, latest};
+  return simple_enum::adl_info{.first = v1, .last = latest};
   }
 
 struct app_settings_t
@@ -90,7 +90,7 @@ enum struct ai_settings_version_e
 consteval auto adl_enum_bounds(ai_settings_version_e)
   {
   using enum ai_settings_version_e;
-  return simple_enum::adl_info{v1, latest};
+  return simple_enum::adl_info{.first = v1, .last = latest};
   }
 
 //

--- a/ai_processing/include/aiprocess/app_settings.h
+++ b/ai_processing/include/aiprocess/app_settings.h
@@ -13,7 +13,7 @@
 namespace aiprocess
   {
 
-enum struct backend_type_e
+enum struct backend_type_e : std::uint8_t
   {
   kate,
   kdevelop
@@ -30,7 +30,7 @@ inline constexpr string_view kate_with_ai_app_settings_file_name{"kate_with_ai_a
 
 inline constexpr string_view kdevcxx_with_ai_ai_settings_file_name{"kdevcxx_with_ai_ai_settings.json"};
 
-enum struct app_settings_version_e
+enum struct app_settings_version_e : std::uint8_t
   {
   v1 = 1,
 
@@ -80,7 +80,7 @@ auto store_app_settings(app_settings_t const & cfg) noexcept -> bool;
 extern template auto store_app_settings<backend_type_e::kdevelop>(app_settings_t const & cfg) noexcept -> bool;
 extern template auto store_app_settings<backend_type_e::kate>(app_settings_t const & cfg) noexcept -> bool;
 
-enum struct ai_settings_version_e
+enum struct ai_settings_version_e : std::uint8_t
   {
   v1 = 1,
   v2,

--- a/ai_processing/include/aiprocess/change_current_dir.h
+++ b/ai_processing/include/aiprocess/change_current_dir.h
@@ -21,7 +21,7 @@ enum struct change_directory_error
 consteval auto adl_enum_bounds(change_directory_error)
   {
   using enum change_directory_error;
-  return simple_enum::adl_info{unhandled_exception, filesystem_error};
+  return simple_enum::adl_info{.first = unhandled_exception, .last = filesystem_error};
   }
 
 [[nodiscard]]

--- a/ai_processing/include/network.h
+++ b/ai_processing/include/network.h
@@ -21,7 +21,7 @@ struct url_components
 
 // auto parse(std::string_view url) -> url_components;
 
-enum struct send_text_to_gpt_error
+enum struct send_text_to_gpt_error : std::uint8_t
   {
   network_error,
   other_exception,

--- a/ai_processing/source/ai_processing.cc
+++ b/ai_processing/source/ai_processing.cc
@@ -128,7 +128,7 @@ try
   {
   using enum process_with_ai_error;
 
-  aiprocess::ai_settings_t aisettings{aiprocess::load_ai_settings()};
+  const aiprocess::ai_settings_t aisettings{aiprocess::load_ai_settings()};
   info("checking api key ..");
   if(!is_valid_openai_bearer_key(aisettings.api_key)) [[unlikely]]
     return unexpected_error(invalid_api_key, "invalid key bailing out");
@@ -149,7 +149,7 @@ try
   if(command_text.empty()) [[unlikely]]
     return unexpected_error(no_valid_command, "command_text is empty nothing to do ..");
 
-  std::string code_text = user_data.substr(end_pos + command_end_delim.length());
+  const std::string code_text = user_data.substr(end_pos + command_end_delim.length());
 
 #ifndef ENABLE_CHAT_COMPLETIONS
   ai_command_json command{.prompt = fmt::format("[{},{}] {}", ai_rules, command_text, code_text)};

--- a/ai_processing/source/log.cc
+++ b/ai_processing/source/log.cc
@@ -34,7 +34,7 @@ static auto create_log_sink(std::string const & path, std::string const & filena
   return std::make_shared<spdlog::sinks::basic_file_sink_mt>(stralgo::stl::merge(path, '/', filename), false);
   }
 
-static std::shared_ptr<spdlog::logger> create_logger(std::string name, spdlog::sinks_init_list sinks)
+static std::shared_ptr<spdlog::logger> create_logger(std::string const & name, spdlog::sinks_init_list sinks)
   {
   auto logger = std::make_shared<spdlog::logger>(name, sinks.begin(), sinks.end());
   logger->flush_on(spdlog::level::err);
@@ -43,8 +43,8 @@ static std::shared_ptr<spdlog::logger> create_logger(std::string name, spdlog::s
 
 void setup_loggers(app_settings_t const & cfg)
   {
-  std::string app_path{get_config_path()};
-  std::string log_path{stralgo::stl::merge(app_path, '/', cfg.log_path)};
+  const std::string app_path{get_config_path()};
+  const std::string log_path{stralgo::stl::merge(app_path, '/', cfg.log_path)};
 
   console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
   console_sink->set_level(cfg.console_log_level);

--- a/src/kate_with_ai/kate_with_ai.cc
+++ b/src/kate_with_ai/kate_with_ai.cc
@@ -63,7 +63,7 @@ kate_with_ai_view::kate_with_ai_view(kate_with_ai * plugin, KTextEditor::MainWin
 
 void kate_with_ai_view::on_view_changed(KTextEditor::View * view) { init_view(view); }
 
-void kate_with_ai_view::init_view(KTextEditor::View * view)
+void kate_with_ai_view::init_view(KTextEditor::View * view) const
   {
   if(!view) [[unlikely]]
     return;

--- a/src/kate_with_ai/kate_with_ai.cc
+++ b/src/kate_with_ai/kate_with_ai.cc
@@ -22,7 +22,7 @@ using aiprocess::warn;
 
 K_PLUGIN_FACTORY_WITH_JSON(kate_with_aiFactory, "kate_with_ai.json", registerPlugin<kate_with_ai>();)
 
-kate_with_ai::kate_with_ai(QObject * parent, QList<QVariant> const &) : KTextEditor::Plugin(parent)
+kate_with_ai::kate_with_ai(QObject * parent, QList<QVariant> const &) : KTextEditor::Plugin{parent}
   {
   log(aiprocess::level::info, "Starting plugin Kate_With_Ai");
   settings = aiprocess::load_app_settings<aiprocess::backend_type_e::kate>();
@@ -30,28 +30,28 @@ kate_with_ai::kate_with_ai(QObject * parent, QList<QVariant> const &) : KTextEdi
   info("Settings loaded");
   }
 
-kate_with_ai::~kate_with_ai() {}
+kate_with_ai::~kate_with_ai() = default;
 
 int kate_with_ai::configPages() const { return 1; }
 
 KTextEditor::ConfigPage * kate_with_ai::configPage(int number, QWidget * parent)
   {
   if(number == 0)
-    return new kate_with_ai_config_page(parent);
+    return new kate_with_ai_config_page{parent};
   return nullptr;  // No other pages to return
   }
 
 QObject * kate_with_ai::createView(KTextEditor::MainWindow * main_window)
   {
-  auto * view = new kate_with_ai_view(this, main_window);
+  auto * view = new kate_with_ai_view{this, main_window};
   return view;
   }
 
 kate_with_ai_view::kate_with_ai_view(kate_with_ai * plugin, KTextEditor::MainWindow * main_window) :
     plugin_{plugin},
-    main_window_(main_window)
+    main_window_{main_window}
   {
-  openai_process_action = new QAction(tr("Process with OpenAI"), this);
+  openai_process_action = new QAction{tr("Process with OpenAI"), this};
   connect(openai_process_action, &QAction::triggered, this, &kate_with_ai_view::on_process_with_ai);
 
   // Connect to the signal that notifies about the current view change

--- a/src/kate_with_ai/kate_with_ai.h
+++ b/src/kate_with_ai/kate_with_ai.h
@@ -19,15 +19,16 @@ class kate_with_ai_view;
 class kate_with_ai : public KTextEditor::Plugin
   {
   Q_OBJECT
+  Q_DISABLE_COPY_MOVE(kate_with_ai)
   friend class kate_with_ai_view;
 
   aiprocess::app_settings_t settings;
 
 public:
-  explicit kate_with_ai(QObject * parent, QList<QVariant> const & = QList<QVariant>());
+  explicit kate_with_ai(QObject * parent, QList<QVariant> const & = QList<QVariant>{});
   ~kate_with_ai() override;
 
-  [[nodiscard]] auto createView(KTextEditor::MainWindow * mainWindow) -> QObject * override;
+  [[nodiscard]] auto createView(KTextEditor::MainWindow * main_window) -> QObject * override;
 
   [[nodiscard]] auto configPages() const -> int override;
   [[nodiscard]] auto configPage(int number, QWidget * parent) -> KTextEditor::ConfigPage* override;
@@ -45,7 +46,7 @@ private slots:
   void on_context_menu_about_to_show(KTextEditor::View * view, QMenu * menu);
 
 private:
-  void init_view(KTextEditor::View * view);
+  void init_view(KTextEditor::View * view) const;
   void on_process_with_ai();
 
   kate_with_ai * plugin_;

--- a/src/kate_with_ai/kate_with_ai.h
+++ b/src/kate_with_ai/kate_with_ai.h
@@ -27,10 +27,10 @@ public:
   explicit kate_with_ai(QObject * parent, QList<QVariant> const & = QList<QVariant>());
   ~kate_with_ai() override;
 
-  QObject * createView(KTextEditor::MainWindow * mainWindow) override;
+  [[nodiscard]] auto createView(KTextEditor::MainWindow * mainWindow) -> QObject * override;
 
-  int configPages() const override;
-  KTextEditor::ConfigPage * configPage(int number, QWidget * parent) override;
+  [[nodiscard]] auto configPages() const -> int override;
+  [[nodiscard]] auto configPage(int number, QWidget * parent) -> KTextEditor::ConfigPage* override;
   };
 
 class kate_with_ai_view : public QWidget

--- a/src/kate_with_ai/kate_with_ai_config_page.cc
+++ b/src/kate_with_ai/kate_with_ai_config_page.cc
@@ -12,20 +12,22 @@
 #include <aiprocess/log.h>
 #endif
 
-kate_with_ai_config_page::kate_with_ai_config_page(QWidget * parent) : KTextEditor::ConfigPage(parent)
+kate_with_ai_config_page::kate_with_ai_config_page(QWidget * parent) : KTextEditor::ConfigPage{parent}
   {
   kdevcxxai::config_page::construct<aiprocess::backend_type_e::kate>(
     *this, ui, std::bind(&kate_with_ai_config_page::emit_changed, this)
   );
   }
 
+kate_with_ai_config_page::~kate_with_ai_config_page() = default;
+
 void kate_with_ai_config_page::emit_changed() { emit changed(); }
 
-QString kate_with_ai_config_page::name() const { return i18n("OpenAI Configuration"); }
+auto kate_with_ai_config_page::name() const -> QString { return i18n("OpenAI Configuration"); }
 
-QString kate_with_ai_config_page::fullName() const { return i18n("Configure Open AI Settings"); }
+auto kate_with_ai_config_page::fullName() const -> QString { return i18n("Configure Open AI Settings"); }
 
-QIcon kate_with_ai_config_page::icon() const { return QIcon::fromTheme("preferences-other"); }
+auto kate_with_ai_config_page::icon() const -> QIcon { return QIcon::fromTheme("preferences-other"); }
 
 void kate_with_ai_config_page::apply() { kdevcxxai::config_page::apply<aiprocess::backend_type_e::kate>(ui); }
 

--- a/src/kate_with_ai/kate_with_ai_config_page.h
+++ b/src/kate_with_ai/kate_with_ai_config_page.h
@@ -12,10 +12,11 @@ class kate_with_ai_config_page : public KTextEditor::ConfigPage
 
 public:
   explicit kate_with_ai_config_page(QWidget * parent = nullptr);
+  ~kate_with_ai_config_page() override;
 
-  QString name() const override;
-  QString fullName() const override;
-  QIcon icon() const override;
+  [[nodiscard]] auto name() const -> QString override;
+  [[nodiscard]] auto fullName() const -> QString override;
+  [[nodiscard]] auto icon() const -> QIcon override;
 
   void apply() override;
   void reset() override;

--- a/src/kate_with_ai/kate_with_ai_config_page.h
+++ b/src/kate_with_ai/kate_with_ai_config_page.h
@@ -9,6 +9,7 @@
 class kate_with_ai_config_page : public KTextEditor::ConfigPage
   {
   Q_OBJECT
+  Q_DISABLE_COPY_MOVE(kate_with_ai_config_page)
 
 public:
   explicit kate_with_ai_config_page(QWidget * parent = nullptr);

--- a/src/kdevcxx_with_ai/kdevcxx_with_ai.cc
+++ b/src/kdevcxx_with_ai/kdevcxx_with_ai.cc
@@ -33,7 +33,7 @@ using aiprocess::warn;
 
 K_PLUGIN_FACTORY_WITH_JSON(cxx_with_gptFactory, "kdevcxx_with_ai.json", registerPlugin<kdevcxx_with_ai>();)
 
-kdevcxx_with_ai::kdevcxx_with_ai(QObject * parent, QVariantList const &) : KDevelop::IPlugin("kdevcxx_with_ai", parent)
+kdevcxx_with_ai::kdevcxx_with_ai(QObject * parent, QVariantList const &) : KDevelop::IPlugin{"kdevcxx_with_ai", parent}
   {
   log(aiprocess::level::info, "Starting plugin KDevCxx_With_Ai");
   settings = aiprocess::load_app_settings<aiprocess::backend_type_e::kdevelop>();
@@ -75,7 +75,7 @@ void kdevcxx_with_ai::on_process_with_ai()
 
 void kdevcxx_with_ai::createActionsForMainWindow(Sublime::MainWindow *, QString &, KActionCollection & actions)
   {
-  QAction * process_with_ai_action = new QAction(QIcon(":/icons/my_icon.png"), tr("Process with OpenAI"), this);
+  auto * process_with_ai_action = new QAction{QIcon(":/icons/my_icon.png"), tr("Process with OpenAI"), this};
   process_with_ai_action->setToolTip(tr("Do something interesting with AI"));
 
   process_with_ai_action->setShortcut(settings.activation_keys);
@@ -94,7 +94,7 @@ auto kdevcxx_with_ai::contextMenuExtension(KDevelop::Context * context, QWidget 
     {
     info("Context menu registered for AI");
     // This is just an example; customize it based on your plugin's functionality
-    QAction * process_with_ai_action = new QAction(QIcon::fromTheme("system-run"), tr("Process with OpenAI"), parent);
+    auto * process_with_ai_action = new QAction{QIcon::fromTheme("system-run"), tr("Process with OpenAI"), parent};
     connect(process_with_ai_action, &QAction::triggered, this, &kdevcxx_with_ai::on_process_with_ai);
 
     // Add your action to the extension
@@ -109,13 +109,13 @@ int kdevcxx_with_ai::configPages() const { return 1; }
 auto kdevcxx_with_ai::configPage(int number, QWidget * parent) -> KDevelop::ConfigPage *
   {
   if(number == 0)
-    return new kdevcxx_with_ai_config_page(this, parent);
+    return new kdevcxx_with_ai_config_page{this, parent};
   return nullptr;  // No other pages to return
   }
 
 void kdevcxx_with_ai::unload() {}
 
-kdevcxx_with_ai::~kdevcxx_with_ai() {}
+kdevcxx_with_ai::~kdevcxx_with_ai() = default;
 
 #include "kdevcxx_with_ai.moc"
 // #include "moc_kdevcxx_with_ai.cpp"

--- a/src/kdevcxx_with_ai/kdevcxx_with_ai.h
+++ b/src/kdevcxx_with_ai/kdevcxx_with_ai.h
@@ -21,15 +21,15 @@ public:
   kdevcxx_with_ai(QObject * parent, QVariantList const & args);
   ~kdevcxx_with_ai() override;
 
-  auto contextMenuExtension(KDevelop::Context * context, QWidget * parent) -> KDevelop::ContextMenuExtension override;
+  [[nodiscard]] auto contextMenuExtension(KDevelop::Context * context, QWidget * parent) -> KDevelop::ContextMenuExtension override;
 
   auto createActionsForMainWindow(Sublime::MainWindow * window, QString & xmlFile, KActionCollection & actions)
     -> void override;
 
-  void unload() override;
+  auto unload() -> void override;
 
-  KDevelop::ConfigPage * configPage(int number, QWidget * parent) override;
-  int configPages() const override;
+  [[nodiscard]] auto configPage(int number, QWidget * parent) ->KDevelop::ConfigPage* override;
+  [[nodiscard]] auto configPages() const -> int override;
 
 private slots:
 

--- a/src/kdevcxx_with_ai/kdevcxx_with_ai.h
+++ b/src/kdevcxx_with_ai/kdevcxx_with_ai.h
@@ -15,6 +15,7 @@
 class kdevcxx_with_ai : public KDevelop::IPlugin
   {
   Q_OBJECT
+  Q_DISABLE_COPY_MOVE(kdevcxx_with_ai)
   aiprocess::app_settings_t settings;
 
 public:

--- a/src/kdevcxx_with_ai/kdevcxx_with_ai_config_page.cc
+++ b/src/kdevcxx_with_ai/kdevcxx_with_ai_config_page.cc
@@ -12,20 +12,22 @@
 #endif
 
 kdevcxx_with_ai_config_page::kdevcxx_with_ai_config_page(KDevelop::IPlugin * plugin, QWidget * parent) :
-    KDevelop::ConfigPage(plugin, nullptr, parent)
+    KDevelop::ConfigPage{plugin, nullptr, parent}
   {
   kdevcxxai::config_page::construct<aiprocess::backend_type_e::kdevelop>(
     *this, ui, std::bind(&kdevcxx_with_ai_config_page::emit_changed, this)
   );
   }
 
+kdevcxx_with_ai_config_page::~kdevcxx_with_ai_config_page() = default;
+
 void kdevcxx_with_ai_config_page::emit_changed() { emit changed(); }
 
-QString kdevcxx_with_ai_config_page::name() const { return i18n("OpenAI Configuration"); }
+auto kdevcxx_with_ai_config_page::name() const -> QString { return i18n("OpenAI Configuration"); }
 
-QString kdevcxx_with_ai_config_page::fullName() const { return i18n("Configure Open AI Settings"); }
+auto kdevcxx_with_ai_config_page::fullName() const -> QString { return i18n("Configure Open AI Settings"); }
 
-QIcon kdevcxx_with_ai_config_page::icon() const { return QIcon::fromTheme("preferences-other"); }
+auto kdevcxx_with_ai_config_page::icon() const -> QIcon { return QIcon::fromTheme("preferences-other"); }
 
 void kdevcxx_with_ai_config_page::apply() { kdevcxxai::config_page::apply<aiprocess::backend_type_e::kdevelop>(ui); }
 

--- a/src/kdevcxx_with_ai/kdevcxx_with_ai_config_page.h
+++ b/src/kdevcxx_with_ai/kdevcxx_with_ai_config_page.h
@@ -12,10 +12,11 @@ class kdevcxx_with_ai_config_page : public KDevelop::ConfigPage
 
 public:
   explicit kdevcxx_with_ai_config_page(KDevelop::IPlugin * plugin, QWidget * parent = nullptr);
+  ~kdevcxx_with_ai_config_page() override;
 
-  QString name() const override;
-  QString fullName() const override;
-  QIcon icon() const override;
+  auto name() const -> QString override;
+  auto fullName() const -> QString override;
+  auto icon() const -> QIcon override;
 
   void apply() override;
   void reset() override;

--- a/src/plugin_common/include/plugin_common.h
+++ b/src/plugin_common/include/plugin_common.h
@@ -32,7 +32,7 @@ inline constexpr auto fist_time_message
     "negating the necessity for a KDevelop restart.\n"
     "Alterations to AI settings will be effective upon the next invocation.";
 
-enum class get_view_file_path_error
+enum class get_view_file_path_error : std::uint8_t
   {
   no_document,
   unhandled_exception

--- a/src/plugin_common/info_dialog.cc
+++ b/src/plugin_common/info_dialog.cc
@@ -6,22 +6,26 @@
 #include <qlabel.h>
 #include <qpushbutton.h>
 
-info_dialog::info_dialog(QString const & title, QString const & text, QWidget * parent) : QDialog(parent)
+info_dialog::info_dialog(QString const & title, QString const & text, QWidget * parent) : QDialog{parent}
   {
   setWindowTitle(title);
 
-  QVBoxLayout * layout = new QVBoxLayout(this);
-  QLabel * label = new QLabel(text, this);
+  auto * layout = new QVBoxLayout{this};
+  auto * label = new QLabel{text, this};
   layout->addWidget(label);
 
   // Optional: Add a button to close the dialog
-  QPushButton * close_button = new QPushButton("Close", this);
+  auto * close_button = new QPushButton{"Close", this};
   connect(close_button, &QPushButton::clicked, this, &info_dialog::accept);
   layout->addWidget(close_button);
 
   setLayout(layout);
   }
 
+<<<<<<< HEAD
+info_dialog::~info_dialog() = default;
+=======
 info_dialog::~info_dialog()
 {}
+>>>>>>> parent of 11cd9f3 (Edit cmake to search locally at first for 3rd party libraries)
 

--- a/src/plugin_common/info_dialog.cc
+++ b/src/plugin_common/info_dialog.cc
@@ -22,10 +22,6 @@ info_dialog::info_dialog(QString const & title, QString const & text, QWidget * 
   setLayout(layout);
   }
 
-<<<<<<< HEAD
 info_dialog::~info_dialog() = default;
-=======
-info_dialog::~info_dialog()
-{}
->>>>>>> parent of 11cd9f3 (Edit cmake to search locally at first for 3rd party libraries)
+
 

--- a/src/plugin_common/info_dialog.h
+++ b/src/plugin_common/info_dialog.h
@@ -17,7 +17,7 @@ class info_dialog : public QDialog
 
 public:
   explicit info_dialog(QString const & title, QString const & text, QWidget * parent = nullptr);
-  
+
   ~info_dialog() override;
   };
 

--- a/src/plugin_common/info_dialog.h
+++ b/src/plugin_common/info_dialog.h
@@ -14,6 +14,7 @@ class QPushButton;
 class info_dialog : public QDialog
   {
   Q_OBJECT
+  Q_DISABLE_COPY_MOVE(info_dialog)
 
 public:
   explicit info_dialog(QString const & title, QString const & text, QWidget * parent = nullptr);

--- a/src/plugin_common/markdown_view.cc
+++ b/src/plugin_common/markdown_view.cc
@@ -25,3 +25,4 @@ void markdown_view::load_markdown(QString const & html_content)
 //   return html_content;
 //   }
 
+markdown_view::~markdown_view() = default;

--- a/src/plugin_common/markdown_view.h
+++ b/src/plugin_common/markdown_view.h
@@ -19,6 +19,8 @@ public:
 
   void load_markdown(QString const & file_path);
 
+  ~markdown_view() override;
+
 private:
   QWebEngineView * web_view;
   };

--- a/src/plugin_common/markdown_view.h
+++ b/src/plugin_common/markdown_view.h
@@ -10,10 +10,11 @@
 class markdown_view : public QDockWidget
   {
   Q_OBJECT
+  Q_DISABLE_COPY_MOVE(markdown_view)
+
 public:
-  explicit markdown_view(QWidget * parent = nullptr) : QDockWidget(parent)
+  explicit markdown_view(QWidget * parent = nullptr) : QDockWidget{parent}, web_view{new QWebEngineView{this}}
     {
-    web_view = new QWebEngineView(this);
     setWidget(web_view);
     }
 

--- a/src/plugin_common/plugin_common.cc
+++ b/src/plugin_common/plugin_common.cc
@@ -165,16 +165,16 @@ namespace config_page
   auto construct(KTextEditor::ConfigPage & w, ui_t & ui, std::function<void()> emit_changed) -> void
     {
     aiprocess::debug("construct() called");
-    QVBoxLayout * main_layout = new QVBoxLayout(&w);
-    QTabWidget * ai_tab_widget = new QTabWidget(&w);
+    auto * main_layout = new QVBoxLayout{&w};
+    auto * ai_tab_widget = new QTabWidget{&w};
     main_layout->addWidget(ai_tab_widget);
 
     // auto emit_changed = [&]() { pemit_chnaged(); };
     // auto emit_changed = [&]<typename... Args>(Args &&...) { pemit_chnaged(); };
 
     // Create a widget to hold the form layout
-    QWidget * ai_form_widget = new QWidget();
-    QFormLayout * ai_form_layout = new QFormLayout(ai_form_widget);
+    auto * ai_form_widget = new QWidget{};
+    auto * ai_form_layout = new QFormLayout{ai_form_widget};
 
     ui.openai_key = config_widget_creator_t<QLineEdit>{ai_form_widget, ai_form_layout}("OpenAI Key:", emit_changed);
     ui.open_ai_model
@@ -186,8 +186,8 @@ namespace config_page
 
     // second page
 
-    QWidget * log_form_widget = new QWidget();
-    QFormLayout * log_form_layout = new QFormLayout(log_form_widget);
+    auto * log_form_widget = new QWidget{};
+    auto * log_form_layout = new QFormLayout{log_form_widget};
 
       {
       config_widget_creator_t<QLineEdit> creator{log_form_widget, log_form_layout};

--- a/src/plugin_common/plugin_common.cc
+++ b/src/plugin_common/plugin_common.cc
@@ -28,282 +28,282 @@
 #endif
 
 namespace kdevcxxai
-  {
-using namespace std::string_view_literals;
-using aiprocess::debug;
-using aiprocess::info;
-using aiprocess::log;
-using aiprocess::warn;
+{
+  using namespace std::string_view_literals;
+  using aiprocess::debug;
+  using aiprocess::info;
+  using aiprocess::log;
+  using aiprocess::warn;
 
-auto get_view_file_path(KTextEditor::View const & view) noexcept -> expected<std::string, get_view_file_path_error>
-try
+  auto get_view_file_path(KTextEditor::View const & view) noexcept -> expected<std::string, get_view_file_path_error>
+  try
   {
-  if(!view.document()) [[unlikely]]
-    return aiprocess::unexpected_error(get_view_file_path_error::no_document, "Document was not saved yet");
+    if(!view.document()) [[unlikely]]
+      return aiprocess::unexpected_error(get_view_file_path_error::no_document, "Document was not saved yet");
 
-  auto document = view.document();
-  return document->url().toLocalFile().toStdString();
+    auto document = view.document();
+    return document->url().toLocalFile().toStdString();
   }
-catch(...)
+  catch(...)
   {
-  return aiprocess::unexpected_error(
-    get_view_file_path_error::unhandled_exception, "error getting path for current view document"
-  );
-  }
-
-auto process_with_ai(KTextEditor::View & view, aiprocess::app_settings_t const & settings) noexcept -> void
-  {
-    {
-    auto aisettings{aiprocess::load_ai_settings()};
-    if(aisettings.api_key.empty())
-      {
-      info_dialog dialog{"KDevCxx_With_Ai key setup", fist_time_message};
-      dialog.exec();
-      return;
-      }
-    }
-
-  using namespace std::chrono_literals;
-
-  auto * document = view.document();
-  if(!document) [[unlikely]]
-    {
-    warn("Invalid view->document");
-    return;
-    }
-
-  info("Processing OpenAI request ...");
-  QProgressDialog progressDialog{"Processing OpenAI Request...", "Cancel", 0, 100};
-  progressDialog.setWindowModality(Qt::WindowModal);
-  progressDialog.show();
-
-  QString selected_text = view.selectionText();
-
-  auto async_result = std::async(
-    std::launch::async,
-    [](QString const & text) -> expected<aiprocess::model_response_text_t, aiprocess::process_with_ai_error>
-    { return aiprocess::process_with_ai(text.toStdString()); },
-    selected_text
-  );
-
-  debug("async to OpenAI executed ...");
-  std::this_thread::yield();
-
-  while(async_result.wait_for(50ms) != std::future_status::ready)
-    QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
-
-  auto result = async_result.get();
-  debug("async to OpenAI done ...");
-
-  if(!result)
-    {
-    aiprocess::li::error("Got error from async {}\n", result.error());
-    KMessageBox::error(
-      &view,
-      QString::fromStdString(stralgo::stl::merge(
-        "Error processing AI request "sv,
-        simple_enum::enum_name(result.error()),
-        "\ncheck detailed log at ~/.config/kdevcxx_with_ai/"sv,
-        settings.log_path
-      )),
-      "Error during processing AI request"
+    return aiprocess::unexpected_error(
+      get_view_file_path_error::unhandled_exception, "error getting path for current view document"
     );
-    return;
-    }
-
-  std::string cur_work_dir{};
-  if(auto path = kdevcxxai::get_view_file_path(view); path.has_value())
-    cur_work_dir = std::move(path.value());
-
-  auto const & response = *result;
-  auto new_text = aiprocess::process_openai_json_response(response, std::move(cur_work_dir));
-  debug("Proocessed response Command Text: {}\nCode Text: {}\n", response.command, response.recived_text);
-
-  if(new_text.empty()) [[unlikely]]
-    return;
-
-  document->replaceText(view.selectionRange(), QString::fromStdString(new_text));
-  debug("document->replaceText called ...");
   }
 
-namespace config_page
+  auto process_with_ai(KTextEditor::View & view, aiprocess::app_settings_t const & settings) noexcept -> void
   {
-  template<typename T>
-  concept callable_with_no_args_returning_void = requires(T t) {
-    { t() } -> std::same_as<void>;
-  };
-
-  template<typename WidgetType>
-  struct config_widget_creator_t
     {
-    QWidget * parent;
-    QFormLayout * form_layout;
-
-    template<callable_with_no_args_returning_void Callable>
-    auto operator()(QString const & label, Callable const & emit_changed) const -> WidgetType *
+      auto aisettings{aiprocess::load_ai_settings()};
+      if(aisettings.api_key.empty())
       {
-      auto * widget = new WidgetType(parent);
-      QObject::connect(widget, &WidgetType::textChanged, parent, std::move(emit_changed));
-      form_layout->addRow(label, widget);
-      return widget;
+        info_dialog dialog{"KDevCxx_With_Ai key setup", fist_time_message};
+        dialog.exec();
+        return;
+      }
+    }
+
+    using namespace std::chrono_literals;
+
+    auto * document = view.document();
+    if(!document) [[unlikely]]
+    {
+      warn("Invalid view->document");
+      return;
+    }
+
+    info("Processing OpenAI request ...");
+    QProgressDialog progressDialog{"Processing OpenAI Request...", "Cancel", 0, 100};
+    progressDialog.setWindowModality(Qt::WindowModal);
+    progressDialog.show();
+
+    QString selected_text = view.selectionText();
+
+    auto async_result = std::async(
+      std::launch::async,
+      [](QString text) -> expected<aiprocess::model_response_text_t, aiprocess::process_with_ai_error>
+      { return aiprocess::process_with_ai(text.toStdString()); },
+                                   selected_text
+    );
+
+    debug("async to OpenAI executed ...");
+    std::this_thread::yield();
+
+    while(async_result.wait_for(50ms) != std::future_status::ready)
+      QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
+
+    auto result = async_result.get();
+    debug("async to OpenAI done ...");
+
+    if(!result)
+    {
+      aiprocess::li::error("Got error from async {}\n", result.error());
+      KMessageBox::error(
+        &view,
+        QString::fromStdString(stralgo::stl::merge(
+          "Error processing AI request "sv,
+          simple_enum::enum_name(result.error()),
+                                                   "\ncheck detailed log at ~/.config/kdevcxx_with_ai/"sv,
+                                                   settings.log_path
+        )),
+        "Error during processing AI request"
+      );
+      return;
+    }
+
+    std::string cur_work_dir{};
+    if(auto path = kdevcxxai::get_view_file_path(view); path.has_value())
+      cur_work_dir = std::move(path.value());
+
+    auto const & response = *result;
+    auto new_text = aiprocess::process_openai_json_response(response, std::move(cur_work_dir));
+    debug("Proocessed response Command Text: {}\nCode Text: {}\n", response.command, response.recived_text);
+
+    if(new_text.empty()) [[unlikely]]
+      return;
+
+    document->replaceText(view.selectionRange(), QString::fromStdString(new_text));
+    debug("document->replaceText called ...");
+  }
+
+  namespace config_page
+  {
+    template<typename T>
+    concept callable_with_no_args_returning_void = requires(T t) {
+      { t() } -> std::same_as<void>;
+    };
+
+    template<typename WidgetType>
+    struct config_widget_creator_t
+    {
+      QWidget * parent;
+      QFormLayout * form_layout;
+
+      template<callable_with_no_args_returning_void Callable>
+      auto operator()(QString const & label, Callable emit_changed) const -> WidgetType *
+      {
+        auto * widget = new WidgetType(parent);
+        QObject::connect(widget, &WidgetType::textChanged, parent, emit_changed);
+        form_layout->addRow(label, widget);
+        return widget;
       }
 
-    template<callable_with_no_args_returning_void Callable>
-    auto operator()(QString const & label, QStringList const & logLevels, Callable const & emit_changed) const -> WidgetType *
+      template<callable_with_no_args_returning_void Callable>
+      auto operator()(QString const & label, QStringList const & logLevels, Callable emit_changed) const -> WidgetType *
       {
-      auto * widget = new WidgetType(parent);
-      QObject::connect(
-        widget, static_cast<void (WidgetType::*)(int)>(&QComboBox::currentIndexChanged), parent, std::move(emit_changed)
-      );
-      form_layout->addRow(label, widget);
-      widget->addItems(logLevels);
-      return widget;
+        auto * widget = new WidgetType(parent);
+        QObject::connect(
+          widget, static_cast<void (WidgetType::*)(int)>(&QComboBox::currentIndexChanged), parent, emit_changed
+        );
+        form_layout->addRow(label, widget);
+        widget->addItems(logLevels);
+        return widget;
       }
     };
 
-  template<aiprocess::backend_type_e backend>
-  auto construct(KTextEditor::ConfigPage & w, ui_t & ui, std::function<void()> const & emit_changed) -> void
+    template<aiprocess::backend_type_e backend>
+    auto construct(KTextEditor::ConfigPage & w, ui_t & ui, std::function<void()> emit_changed) -> void
     {
-    aiprocess::debug("construct() called");
-    auto * main_layout = new QVBoxLayout{&w};
-    auto * ai_tab_widget = new QTabWidget{&w};
-    main_layout->addWidget(ai_tab_widget);
+      aiprocess::debug("construct() called");
+      QVBoxLayout * main_layout = new QVBoxLayout(&w);
+      QTabWidget * ai_tab_widget = new QTabWidget(&w);
+      main_layout->addWidget(ai_tab_widget);
 
-    // auto emit_changed = [&]() { pemit_chnaged(); };
-    // auto emit_changed = [&]<typename... Args>(Args &&...) { pemit_chnaged(); };
+      // auto emit_changed = [&]() { pemit_chnaged(); };
+      // auto emit_changed = [&]<typename... Args>(Args &&...) { pemit_chnaged(); };
 
-    // Create a widget to hold the form layout
-    auto * ai_form_widget = new QWidget{};
-    auto * ai_form_layout = new QFormLayout{ai_form_widget};
+      // Create a widget to hold the form layout
+      QWidget * ai_form_widget = new QWidget();
+      QFormLayout * ai_form_layout = new QFormLayout(ai_form_widget);
 
-    ui.openai_key = config_widget_creator_t<QLineEdit>{ai_form_widget, ai_form_layout}("OpenAI Key:", emit_changed);
-    ui.open_ai_model
+      ui.openai_key = config_widget_creator_t<QLineEdit>{ai_form_widget, ai_form_layout}("OpenAI Key:", emit_changed);
+      ui.open_ai_model
       = config_widget_creator_t<QLineEdit>{ai_form_widget, ai_form_layout}("OpenAI Model:", emit_changed);
-    ui.language_rules
+      ui.language_rules
       = config_widget_creator_t<QPlainTextEdit>{ai_form_widget, ai_form_layout}("Language Rules:", emit_changed);
 
-    ai_tab_widget->addTab(ai_form_widget, i18n("AI Configuration"));
+      ai_tab_widget->addTab(ai_form_widget, i18n("AI Configuration"));
 
-    // second page
+      // second page
 
-    auto * log_form_widget = new QWidget{};
-    auto * log_form_layout = new QFormLayout{log_form_widget};
+      QWidget * log_form_widget = new QWidget();
+      QFormLayout * log_form_layout = new QFormLayout(log_form_widget);
 
       {
-      const config_widget_creator_t<QLineEdit> creator{log_form_widget, log_form_layout};
-      ui.log_path_edit = creator("Log Path:", emit_changed);
-      ui.console_log_pattern_edit = creator("Console Log Pattern:", emit_changed);
-      ui.general_log_pattern_edit = creator("General Log Pattern:", emit_changed);
-      ui.snippet_log_pattern_edit = creator("Snippet Log Pattern:", emit_changed);
-      ui.important_log_pattern_edit = creator("Important Log Pattern:", emit_changed);
+        config_widget_creator_t<QLineEdit> creator{log_form_widget, log_form_layout};
+        ui.log_path_edit = creator("Log Path:", emit_changed);
+        ui.console_log_pattern_edit = creator("Console Log Pattern:", emit_changed);
+        ui.general_log_pattern_edit = creator("General Log Pattern:", emit_changed);
+        ui.snippet_log_pattern_edit = creator("Snippet Log Pattern:", emit_changed);
+        ui.important_log_pattern_edit = creator("Important Log Pattern:", emit_changed);
       }
 
       {
-      const QStringList logLevels = {"trace", "debug", "info", "warn", "error", "critical"};
-      const config_widget_creator_t<QComboBox> creator{log_form_widget, log_form_layout};
-      ui.console_log_level_combo = creator("Console Log Pattern:", logLevels, emit_changed);
-      ui.general_log_level_combo = creator("General Log Level:", logLevels, emit_changed);
-      ui.snippet_log_level_combo = creator("Snippet Log Pattern:", logLevels, emit_changed);
-      ui.important_log_level_combo = creator("Important Log Pattern:", logLevels, emit_changed);
+        QStringList logLevels = {"trace", "debug", "info", "warn", "error", "critical"};
+        config_widget_creator_t<QComboBox> creator{log_form_widget, log_form_layout};
+        ui.console_log_level_combo = creator("Console Log Pattern:", logLevels, emit_changed);
+        ui.general_log_level_combo = creator("General Log Level:", logLevels, emit_changed);
+        ui.snippet_log_level_combo = creator("Snippet Log Pattern:", logLevels, emit_changed);
+        ui.important_log_level_combo = creator("Important Log Pattern:", logLevels, emit_changed);
       }
 
-    ui.flush_every_spin = new QSpinBox(log_form_widget);
-    ui.flush_every_spin->setMinimum(1);
-    ui.flush_every_spin->setMaximum(60);
-    ui.flush_every_spin->setValue(3);
-    log_form_layout->addRow(i18n("Flush Every (seconds):"), ui.flush_every_spin);
+      ui.flush_every_spin = new QSpinBox(log_form_widget);
+      ui.flush_every_spin->setMinimum(1);
+      ui.flush_every_spin->setMaximum(60);
+      ui.flush_every_spin->setValue(3);
+      log_form_layout->addRow(i18n("Flush Every (seconds):"), ui.flush_every_spin);
 
-    ui.activation_keys_spin = new QSpinBox(log_form_widget);
-    ui.activation_keys_spin->setMinimum(0);
-    ui.activation_keys_spin->setMaximum(std::numeric_limits<int>::max());
-    log_form_layout->addRow(i18n("Activation Keys:"), ui.activation_keys_spin);
+      ui.activation_keys_spin = new QSpinBox(log_form_widget);
+      ui.activation_keys_spin->setMinimum(0);
+      ui.activation_keys_spin->setMaximum(std::numeric_limits<int>::max());
+      log_form_layout->addRow(i18n("Activation Keys:"), ui.activation_keys_spin);
 
-    ai_tab_widget->addTab(log_form_widget, i18n("Logging"));
-    reset<backend>(ui);
-    aiprocess::debug("construct() end");
+      ai_tab_widget->addTab(log_form_widget, i18n("Logging"));
+      reset<backend>(ui);
+      aiprocess::debug("construct() end");
     }
 
-  template auto
+    template auto
     construct<aiprocess::backend_type_e::kdevelop>(KTextEditor::ConfigPage &, ui_t &, std::function<void()>) -> void;
-  template auto
+    template auto
     construct<aiprocess::backend_type_e::kate>(KTextEditor::ConfigPage &, ui_t &, std::function<void()>) -> void;
 
-  template<aiprocess::backend_type_e backend>
-  auto apply(ui_t & ui) -> void
+    template<aiprocess::backend_type_e backend>
+    auto apply(ui_t & ui) -> void
     {
-    aiprocess::debug("apply() called");
-    aiprocess::store_ai_settings(aiprocess::ai_settings_t{
-      .api_key = ui.openai_key->text().toStdString(),
-      .cxx_rules = ui.language_rules->toPlainText().toStdString(),
-      .gpt_model = ui.open_ai_model->text().toStdString()
-    });
-    using level_enum = aiprocess::app_settings_t::level_enum;
-    aiprocess::store_app_settings<backend>(aiprocess::app_settings_t{
-      .log_path = ui.log_path_edit->text().toStdString(),
-      .console_log_pattern = ui.console_log_pattern_edit->text().toStdString(),
-      .general_log_pattern = ui.general_log_pattern_edit->text().toStdString(),
-      .snippet_log_pattern = ui.snippet_log_pattern_edit->text().toStdString(),
-      .important_log_pattern = ui.important_log_pattern_edit->text().toStdString(),
-      .console_log_level = level_enum(ui.console_log_level_combo->currentIndex()),
-      .general_log_level = level_enum(ui.general_log_level_combo->currentIndex()),
-      .snippet_log_level = level_enum(ui.snippet_log_level_combo->currentIndex()),
-      .important_log_level = level_enum(ui.important_log_level_combo->currentIndex()),
-      .activation_keys = ui.activation_keys_spin->value()
-    });
-    aiprocess::debug("apply() end");
+      aiprocess::debug("apply() called");
+      aiprocess::store_ai_settings(aiprocess::ai_settings_t{
+        .api_key = ui.openai_key->text().toStdString(),
+                                   .cxx_rules = ui.language_rules->toPlainText().toStdString(),
+                                   .gpt_model = ui.open_ai_model->text().toStdString()
+      });
+      using level_enum = aiprocess::app_settings_t::level_enum;
+      aiprocess::store_app_settings<backend>(aiprocess::app_settings_t{
+        .log_path = ui.log_path_edit->text().toStdString(),
+                                             .console_log_pattern = ui.console_log_pattern_edit->text().toStdString(),
+                                             .general_log_pattern = ui.general_log_pattern_edit->text().toStdString(),
+                                             .snippet_log_pattern = ui.snippet_log_pattern_edit->text().toStdString(),
+                                             .important_log_pattern = ui.important_log_pattern_edit->text().toStdString(),
+                                             .console_log_level = level_enum(ui.console_log_level_combo->currentIndex()),
+                                             .general_log_level = level_enum(ui.general_log_level_combo->currentIndex()),
+                                             .snippet_log_level = level_enum(ui.snippet_log_level_combo->currentIndex()),
+                                             .important_log_level = level_enum(ui.important_log_level_combo->currentIndex()),
+                                             .activation_keys = ui.activation_keys_spin->value()
+      });
+      aiprocess::debug("apply() end");
     }
 
-  template auto apply<aiprocess::backend_type_e::kdevelop>(ui_t &) -> void;
-  template auto apply<aiprocess::backend_type_e::kate>(ui_t &) -> void;
+    template auto apply<aiprocess::backend_type_e::kdevelop>(ui_t &) -> void;
+    template auto apply<aiprocess::backend_type_e::kate>(ui_t &) -> void;
 
-  template<aiprocess::backend_type_e backend>
-  auto reset(ui_t & ui) -> void
+    template<aiprocess::backend_type_e backend>
+    auto reset(ui_t & ui) -> void
     {
-    aiprocess::debug("reset() called");
+      aiprocess::debug("reset() called");
       {
-      const aiprocess::ai_settings_t settings = aiprocess::load_ai_settings();
-      ui.language_rules->setPlainText(QString::fromStdString(settings.cxx_rules));
-      ui.openai_key->setText(QString::fromStdString(settings.api_key));
-      ui.open_ai_model->setText(QString::fromStdString(settings.gpt_model));
+        aiprocess::ai_settings_t settings = aiprocess::load_ai_settings();
+        ui.language_rules->setPlainText(QString::fromStdString(settings.cxx_rules));
+        ui.openai_key->setText(QString::fromStdString(settings.api_key));
+        ui.open_ai_model->setText(QString::fromStdString(settings.gpt_model));
       }
 
       // Second page settings
 
       {
-      const aiprocess::app_settings_t settings{aiprocess::load_app_settings<backend>()};
-      ui.log_path_edit->setText(QString::fromStdString(settings.log_path));
-      ui.console_log_pattern_edit->setText(QString::fromStdString(settings.console_log_pattern));
-      ui.general_log_pattern_edit->setText(QString::fromStdString(settings.general_log_pattern));
-      ui.snippet_log_pattern_edit->setText(QString::fromStdString(settings.snippet_log_pattern));
-      ui.important_log_pattern_edit->setText(QString::fromStdString(settings.important_log_pattern));
+        aiprocess::app_settings_t settings{aiprocess::load_app_settings<backend>()};
+        ui.log_path_edit->setText(QString::fromStdString(settings.log_path));
+        ui.console_log_pattern_edit->setText(QString::fromStdString(settings.console_log_pattern));
+        ui.general_log_pattern_edit->setText(QString::fromStdString(settings.general_log_pattern));
+        ui.snippet_log_pattern_edit->setText(QString::fromStdString(settings.snippet_log_pattern));
+        ui.important_log_pattern_edit->setText(QString::fromStdString(settings.important_log_pattern));
 
-      auto set_combo_index = [](QComboBox * comboBox, auto enumValue)
-      {
-        auto ix{simple_enum::enum_index(enumValue)};
-        if(ix.has_value())
-          comboBox->setCurrentIndex(*ix);
-      };
-      set_combo_index(ui.console_log_level_combo, settings.console_log_level);
-      set_combo_index(ui.general_log_level_combo, settings.general_log_level);
-      set_combo_index(ui.snippet_log_level_combo, settings.snippet_log_level);
-      set_combo_index(ui.important_log_level_combo, settings.important_log_level);
+        auto set_combo_index = [](QComboBox * comboBox, auto enumValue)
+        {
+          auto ix{simple_enum::enum_index(enumValue)};
+          if(ix.has_value())
+            comboBox->setCurrentIndex(*ix);
+        };
+        set_combo_index(ui.console_log_level_combo, settings.console_log_level);
+        set_combo_index(ui.general_log_level_combo, settings.general_log_level);
+        set_combo_index(ui.snippet_log_level_combo, settings.snippet_log_level);
+        set_combo_index(ui.important_log_level_combo, settings.important_log_level);
 
-      ui.activation_keys_spin->setValue(settings.activation_keys);
+        ui.activation_keys_spin->setValue(settings.activation_keys);
       }
     }
 
-  template auto reset<aiprocess::backend_type_e::kdevelop>(ui_t &) -> void;
-  template auto reset<aiprocess::backend_type_e::kate>(ui_t &) -> void;
+    template auto reset<aiprocess::backend_type_e::kdevelop>(ui_t &) -> void;
+    template auto reset<aiprocess::backend_type_e::kate>(ui_t &) -> void;
 
-  auto defaults(ui_t & ui) -> void
+    auto defaults(ui_t & ui) -> void
     {
-    aiprocess::debug("defaults() called");
-    ui.language_rules->setPlainText(
-      QString::fromUtf8(aiprocess::default_ai_rules.data(), aiprocess::default_ai_rules.size())
-    );
-    ui.open_ai_model->setText(
-      QString::fromUtf8(aiprocess::default_gpt_model.data(), aiprocess::default_gpt_model.size())
-    );
+      aiprocess::debug("defaults() called");
+      ui.language_rules->setPlainText(
+        QString::fromUtf8(aiprocess::default_ai_rules.data(), aiprocess::default_ai_rules.size())
+      );
+      ui.open_ai_model->setText(
+        QString::fromUtf8(aiprocess::default_gpt_model.data(), aiprocess::default_gpt_model.size())
+      );
     }
   }  // namespace config_page
-  }  // namespace kdevcxxai
+}  // namespace kdevcxxai


### PR DESCRIPTION
This PR applies the `default` keywords to empty dtors, `Q_DISABLE_COPY_MOVE` macro to specifically delete any move or copy operation, const qualifies some variables and functions etc.